### PR TITLE
86c4qxme1/feature/idle-lambdas

### DIFF
--- a/norman_objects/messages/asset_message.py
+++ b/norman_objects/messages/asset_message.py
@@ -1,5 +1,6 @@
 from pydantic import root_validator
 
+from norman_objects.files.file_properties import FileProperties
 from norman_objects.messages.entity_type import EntityType
 from norman_objects.messages.file_message import FileMessage
 from norman_objects.messages.model_message import ModelMessage
@@ -10,6 +11,7 @@ from norman_objects.status_flags.status_flag import StatusFlag
 
 class AssetMessage(ModelMessage, FileMessage):
     asset: ModelAsset
+    file_properties: FileProperties
 
     @root_validator
     def validate_account_id(cls, values):

--- a/norman_objects/messages/file_message.py
+++ b/norman_objects/messages/file_message.py
@@ -2,5 +2,15 @@ from norman_objects.files.file_properties import FileProperties
 from norman_objects.messages.norman_base_message import NormanBaseMessage
 
 
-class FileMessage(NormanBaseMessage):
-    file_properties: FileProperties
+class FileMessage:
+    """
+        Pydantic allows inheritance only from a single BaseModel.
+        This change forces every class that inherits from this class
+        to define a file properties field
+    """
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if "file_properties" not in getattr(cls, "__annotations__", {}):
+            raise TypeError(
+                f"{cls.__name__} must declare 'file_properties' field"
+            )

--- a/norman_objects/messages/input_message.py
+++ b/norman_objects/messages/input_message.py
@@ -1,5 +1,6 @@
 from pydantic import root_validator
 
+from norman_objects.files.file_properties import FileProperties
 from norman_objects.inputs.invocation_input import InvocationInput
 from norman_objects.invocations.invocation import Invocation
 from norman_objects.messages.entity_type import EntityType
@@ -10,6 +11,7 @@ from norman_objects.status_flags.status_flag import StatusFlag
 
 class InputMessage(InvocationMessage, FileMessage):
     input: InvocationInput
+    file_properties: FileProperties
 
     @root_validator
     def validate_account_id(cls, values):

--- a/norman_objects/messages/output_message.py
+++ b/norman_objects/messages/output_message.py
@@ -1,5 +1,6 @@
 from pydantic import root_validator
 
+from norman_objects.files.file_properties import FileProperties
 from norman_objects.invocations.invocation import Invocation
 from norman_objects.messages.entity_type import EntityType
 from norman_objects.messages.file_message import FileMessage
@@ -10,6 +11,7 @@ from norman_objects.status_flags.status_flag import StatusFlag
 
 class OutputMessage(InvocationMessage, FileMessage):
     output: InvocationOutput
+    file_properties: FileProperties
 
     @root_validator
     def validate_account_id(cls, values):


### PR DESCRIPTION
Fixing a bug in which pydantic did not allow us to inherit from multiple BaseModels, so we force every class that inherits from file_message.py to define its own FileProperties.

(#86c4qxme1)