### PR TITLE
86c53wnqh/bug/model-invoke-by-non-owner

### DIFF
--- a/norman_objects/messages/invocation_message.py
+++ b/norman_objects/messages/invocation_message.py
@@ -12,8 +12,6 @@ class InvocationMessage(ModelMessage):
 
     @root_validator
     def validate_account_id(cls, values):
-        super().validate_account_id(values)
-
         account_id: str = values.get("account_id")
         invocation: Invocation = values.get("invocation")
 


### PR DESCRIPTION
Removed redundant super call in `validate_account_id` method.

(#86c53wnqh)