### PR TITLE
86c5fu6mf/bug/invalid-import

### DIFF
--- a/norman_objects/services/file_pull/download/tracked_asset_download.py
+++ b/norman_objects/services/file_pull/download/tracked_asset_download.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from typing import Literal
 
 from typing_extensions import override
@@ -24,7 +24,7 @@ class TrackedAssetDownload(TrackedDownload):
     @override
     def to_message(self, flag_value: StatusFlagValue):
         access_token = NormanAccessContext.get()
-        update_time = datetime.now(UTC)
+        update_time = datetime.now(timezone.utc)
 
         sns_message = AssetMessage(
             access_token=access_token,

--- a/norman_objects/services/file_pull/download/tracked_input_download.py
+++ b/norman_objects/services/file_pull/download/tracked_input_download.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from typing import Literal
 
 from typing_extensions import override
@@ -26,7 +26,7 @@ class TrackedInputDownload(TrackedDownload):
     @override
     def to_message(self, flag_value: StatusFlagValue):
         access_token = NormanAccessContext.get()
-        update_time = datetime.now(UTC)
+        update_time = datetime.now(timezone.utc)
 
         sns_message = InputMessage(
             access_token=access_token,

--- a/norman_objects/services/file_pull/download/tracked_output_download.py
+++ b/norman_objects/services/file_pull/download/tracked_output_download.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from typing import Literal
 
 from typing_extensions import override
@@ -26,7 +26,7 @@ class TrackedOutputDownload(TrackedDownload):
     @override
     def to_message(self, flag_value: StatusFlagValue):
         access_token = NormanAccessContext.get()
-        update_time = datetime.now(UTC)
+        update_time = datetime.now(timezone.utc)
 
         sns_message = OutputMessage(
             access_token=access_token,

--- a/norman_objects/services/file_pull/requests/file_download_request.py
+++ b/norman_objects/services/file_pull/requests/file_download_request.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from typing import List
 
 from norman_objects.norman_base_model import NormanBaseModel
@@ -27,7 +27,7 @@ class NormanFileDownloadRequest(NormanBaseModel):
         raise NotImplementedError("Tracked download config subclasses must be able to serialize to a fallback sns message")
 
     def to_status_flag(self, flag_value: StatusFlagValue):
-        update_time = datetime.now(UTC)
+        update_time = datetime.now(timezone.utc)
 
         return StatusFlag(
             account_id=self.account_id,


### PR DESCRIPTION
Replaced deprecated `UTC` with `timezone.utc` for date handling.

(#86c5fu6mf)