### PR TITLE
86c5jgvza/bug/wrong-relation-in-and-action

### DIFF
--- a/norman_objects/shared/queries/filter_clauses/filter_clause.py
+++ b/norman_objects/shared/queries/filter_clauses/filter_clause.py
@@ -88,7 +88,7 @@ class FilterClause(NormanBaseModel):
 
         return FilterClause(
             children = [*self.children, *other.children],
-            join_condition = self.join_condition
+            join_condition = UnaryRelation.AND
         )
 
     def validate_expression(self, allowed_tables_and_columns: dict[str, set[str]]):


### PR DESCRIPTION
Updated `join_condition` to use `UnaryRelation.AND` in filter clause.

(#86c5jgvza)