### PR TITLE
86c76wkyc/bug/latest-version-always-active

### DIFF
--- a/norman_objects/shared/models/model_version.py
+++ b/norman_objects/shared/models/model_version.py
@@ -21,7 +21,7 @@ class ModelVersion(ModelVersionPreview):
     update_time: NormalizedDateTime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     build_status: ModelBuildStatus
-    active: bool = True
+    active: bool = False
 
     label: str
     short_description: str


### PR DESCRIPTION
Setting the model version active field to be False initially, we will set it up later to be True if the build is successful.

Setting the model version active field to be False initially, we will set it up later to be True if the build is successful.

(#86c76wkyc)